### PR TITLE
fix github ribbon when on small screen

### DIFF
--- a/user/themes/d2draft/css/style.css
+++ b/user/themes/d2draft/css/style.css
@@ -479,6 +479,11 @@
 			width: 100%;
 			padding-left: 0;
 		}
+		
+		.github {
+  		width: 25%;
+		}
+		
 	}
 
 /* for max-width 768px */


### PR DESCRIPTION
fix css to ensmaller github ribbon when on max-width 640px
